### PR TITLE
CI: Build and upload release package to assets.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       PICO_SDK_PATH: $GITHUB_WORKSPACE/pico-sdk
       PIMORONI_PICO_LIBS: $GITHUB_WORKSPACE/pimoroni-pico
-      RELEASE_FILE: ${{github.event.repository.name}}-${{github.event.release.tag_name}}
+      RELEASE_FILE: ${{github.event.repository.name}}-${{github.event.release.tag_name || github.sha}}
 
     steps:
     - name: Checkout Code
@@ -71,19 +71,33 @@ jobs:
       run: |
         cmake --build . --config $BUILD_TYPE -j 2
 
-    - name: Upload build
+    - name: Upload normal build
       if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
-          name: ${{github.event.repository.name}}-build
-          path: ${{runner.workspace}}/build/${{github.event.repository.name}}.*
+          name: pico-stick-build
+          path: ${{runner.workspace}}/build/pico-stick.*
 
-    - name: Build Release Packages
-      if: github.event_name == 'release'
+    - name: Upload widescreen build
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+          name: pico-stick-wide-build
+          path: ${{runner.workspace}}/build/pico-stick-wide.*
+
+    - name: Build release package
+      if: success()
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: |
         cmake --build . --config $BUILD_TYPE --target package -j 2
+
+    - name: Upload release package
+      if: success()
+      uses: actions/upload-artifact@v3
+      with:
+          name: ${{env.RELEASE_FILE}}.zip
+          path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
 
     - name: Upload .zip
       if: github.event_name == 'release'


### PR DESCRIPTION
Slight tweak to:

1. Include a zip of pico-stick-wide artefacts just in case they are useful for a build failure
2. Include the release .zip in regular CI builds